### PR TITLE
Upgrade Spring Boot parent to 3.5.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.5</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
+        <parent>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>3.5.6</version>
+                <relativePath/> <!-- lookup parent from repository -->
+        </parent>
 	<groupId>cl.duoc</groupId>
 	<artifactId>DevOps</artifactId>
 	<version>0.0.1-SNAPSHOT</version>


### PR DESCRIPTION
## Summary
- bump the Spring Boot starter parent to version 3.5.6 so the web and test starters pull in patched transitive dependencies

## Testing
- ⚠️ `./mvnw -q -DskipTests package` *(fails: unable to download Maven wrapper distribution due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6908356b947883268b262f5b2022457b