### PR TITLE
Remove unused formatter constant from controller

### DIFF
--- a/src/main/java/cl/duoc/devops/Controller.java
+++ b/src/main/java/cl/duoc/devops/Controller.java
@@ -17,8 +17,6 @@ public class Controller {
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final DateTimeFormatter FECHA_FORMATTER =
             DateTimeFormatter.ofPattern("yyyy-MM-dd");
-    private static final DateTimeFormatter FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
     @GetMapping("/")
     public String getHora(@RequestParam(value = "nombre", required = false) String nombre) {
         LocalDateTime now = LocalDateTime.now();


### PR DESCRIPTION
## Summary
- remove the unused DateTimeFormatter constant from the main controller to eliminate the warning

## Testing
- mvn test *(fails: Unable to download parent POM due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_69083ebfe7bc8326a7e60c15f2f2fcc1