### PR TITLE
Prevent Sonar analysis when credentials are placeholders

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,7 +158,16 @@ jobs:
           SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
           SONAR_PROJECTKEY: ${{ secrets.SONAR_PROJECTKEY }}
         run: |
-          if [ -z "${SONAR_TOKEN}" ] || [ -z "${SONAR_ORGANIZATION}" ] || [ -z "${SONAR_PROJECTKEY}" ]; then
+          is_placeholder() {
+            case "$1" in
+              ""|REPLACE_WITH*|replace_with*) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
+          if is_placeholder "${SONAR_TOKEN}" || \
+             is_placeholder "${SONAR_ORGANIZATION}" || \
+             is_placeholder "${SONAR_PROJECTKEY}"; then
             echo "SonarCloud credentials are not fully configured. Skipping analysis."
             echo "enabled=false" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary
- ensure the SonarCloud gate in ci.yaml treats placeholder values as missing so the analysis step is skipped when credentials are not configured

## Testing
- ./mvnw -B -U clean verify *(fails: unable to download Maven wrapper distribution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_6908404180088326824cb33a85dc252a